### PR TITLE
Fix errors on Linux

### DIFF
--- a/modules/msccd_tokenizer/pom.xml
+++ b/modules/msccd_tokenizer/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>18</maven.compiler.source>
-    <maven.compiler.target>18</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/modules/msccd_tokenizer/src/main/java/org/nagoya_u/ertl/sa/TokenBag.java
+++ b/modules/msccd_tokenizer/src/main/java/org/nagoya_u/ertl/sa/TokenBag.java
@@ -57,7 +57,7 @@ public class TokenBag{
         // if (str.equalsIgnoreCase(str)){
         //     str = str.replaceAll("\n", "");
         // }
-        final String pattern = "\s";
+        final String pattern = "\\s";
         str = str.replaceAll(pattern, "");
         return str;
     }

--- a/scripts/blockPairOutput.py
+++ b/scripts/blockPairOutput.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # taskId = "10"
     # detectionId = "1"
     # outputFile = 'output.txt'
-    fileList  = MSCCD_ROOT + "tasks/task" + taskId + "/filelist.txt"
+    fileList  = MSCCD_ROOT + "tasks/task" + taskId + "/fileList.txt"
     cloneList = MSCCD_ROOT + "tasks/task" + taskId + "/detection" + detectionId + "/pairs.file"
     bagList   = MSCCD_ROOT + "tasks/task" + taskId + "/tokenBags"
     res = []

--- a/scripts/filePairOutput.py
+++ b/scripts/filePairOutput.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     # taskId = "1"
     # detectionId = "1"
     # outputFile = 'output.txt'
-    fileList  = MSCCD_ROOT + "tasks/task" + taskId + "/filelist.txt"
+    fileList  = MSCCD_ROOT + "tasks/task" + taskId + "/fileList.txt"
     cloneList = MSCCD_ROOT + "tasks/task" + taskId + "/detection" + detectionId + "/pairs.file"
     res = []
     

--- a/scripts/htmlReportGeneration.py
+++ b/scripts/htmlReportGeneration.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
     # detectionId = "1"
     # outputFile = "test.html"
 
-    fileList  = MSCCD_PATH + "/tasks/task" + taskId + "/filelist.txt"
+    fileList  = MSCCD_PATH + "/tasks/task" + taskId + "/fileList.txt"
     cloneList = MSCCD_PATH + "/tasks/task" + taskId + "/detection" + detectionId + "/pairs.file"
     bagList   = MSCCD_PATH + "/tasks/task" + taskId + "/tokenBags"
 


### PR DESCRIPTION
I tried to compile the project as specified in the README but failed because part of modules/msccd_tokenizers/pom.xml  is set to use Java 18 instead of Java 11 as specified in the README. I updated this file to use Java 11.
I then was unable to compile with maven because there was an invalid escape error in TokenBag.java which I corrected.
Finally, I had trouble running the project because some path names in the scripts were incorrect.
After making these changes I was able to use the tool.

Thank you for making this tool available! 